### PR TITLE
mdl-ify form-element-label and inputbox for

### DIFF
--- a/mdl.libraries.yml
+++ b/mdl.libraries.yml
@@ -7,6 +7,14 @@ mdl:
   dependencies:
     - mdl/materialIcons
     - mdl/roboto
+
+mdl.selectfield:
+  css:
+    component:
+      /libraries/mdl-selectfield/mdl-selectfield.min.css: {}
+  js:
+    /libraries/mdl-selectfield/mdl-selectfield.min.js: {}
+
 materialIcons:
   css:
     theme:

--- a/mdl.theme
+++ b/mdl.theme
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Template\Attribute;
+
 function mdl_library_info_alter(&$libraries, $extension)
 {
     if ($extension === 'mdl' && isset($libraries['mdl'])) {
@@ -184,3 +186,69 @@ function mdl_preprocess_menu(&$variables, $hook) {
     }
 }
 
+/**
+ * Transform form elements to MDL input fields
+ **/
+function mdl_preprocess_textarea(&$variables) {
+  $variables['attributes']['class'][] = 'mdl-textfield__input';
+}
+
+function mdl_preprocess_input(&$variables) {
+  if ($variables['element']['#type'] == 'textfield') {
+    $variables['attributes']['class'][] = 'mdl-textfield__input';
+    if (empty($variables['attributes']['placeholder'])) {
+      unset($variables['attributes']['placeholder']);
+    }
+  }
+  else if ($variables['element']['#type'] == 'submit') {
+    $variables['attributes']['class'][] = 'mdl-button';
+    $variables['attributes']['class'][] = 'mdl-js-button';
+    $variables['attributes']['class'][] = 'mdl-button--raised';
+    $variables['attributes']['class'][] = 'mdl-js-ripple-effect';
+    if ($variables['element']['#button_type'] == 'primary') {
+      $variables['attributes']['class'][] = 'mdl-button--accent';
+    }
+
+    //$variables['value'] = $variables['attributes']['value'];
+    //unset($variables['attributes']['value']);
+  }
+}
+
+function mdl_preprocess_select(&$variables) {
+  $variables['attributes']['class'][] = 'mdl-selectfield__select';
+  $variables['#attached']['library'][] = 'mdl/mdl.selectfield';
+}
+
+function mdl_preprocess_form_element(&$variables) {
+  if ($variables['type'] == 'textfield') {
+    $variables['label_display'] = 'after';
+    $variables['label']['#attributes']['class'][] = 'mdl-textfield__label';
+    $variables['attributes'] = new Attribute();
+    $variables['attributes']->addClass('mdl-textfield');
+    $variables['attributes']->addClass('mdl-js-textfield');
+    $variables['attributes']->addClass('mdl-textfield--floating-label');
+  } else if ($variables['type'] == 'textarea') {
+    $variables['label_display'] = 'after';
+    $variables['label']['#attributes']['class'][] = 'mdl-textfield__label';
+    $variables['attributes'] = new Attribute();
+    $variables['attributes']->addClass('mdl-textfield');
+    $variables['attributes']->addClass('mdl-js-textfield');
+    $variables['attributes']->addClass('mdl-textfield--floating-label');
+  } else if ($variables['type'] == 'select') {
+    $variables['label_display'] = 'after';
+    $variables['label']['#attributes']['class'][] = 'mdl-selectfield__label';
+    $variables['label']['#icon'] = 'arrow_drop_down';
+    $variables['label']['#icon_attributes']['class'][] = 'mdl-selectfield__icon';
+    $variables['attributes'] = new Attribute();
+    $variables['attributes']->addClass('mdl-selectfield');
+    $variables['attributes']->addClass('mdl-js-selectfield');
+    $variables['attributes']->addClass('mdl-selectfield--floating-label');
+  }
+}
+
+function mdl_preprocess_form_element_label(&$variables) {
+  if ($variables['element']['#icon']) {
+    $variables['icon'] = $variables['element']['#icon'];
+    $variables['icon_attributes'] = new Attribute($variables['element']['#icon_attributes']);
+  }
+}

--- a/mdl.theme
+++ b/mdl.theme
@@ -194,7 +194,7 @@ function mdl_preprocess_textarea(&$variables) {
 }
 
 function mdl_preprocess_input(&$variables) {
-  if ($variables['element']['#type'] == 'textfield') {
+  if (in_array($variables['element']['#type'],[ 'textfield', 'search', 'password'])) {
     $variables['attributes']['class'][] = 'mdl-textfield__input';
     if (empty($variables['attributes']['placeholder'])) {
       unset($variables['attributes']['placeholder']);
@@ -220,14 +220,19 @@ function mdl_preprocess_select(&$variables) {
 }
 
 function mdl_preprocess_form_element(&$variables) {
-  if ($variables['type'] == 'textfield') {
+  if (in_array($variables['type'], ['textfield', 'search', 'password'])) {
     $variables['label_display'] = 'after';
     $variables['label']['#attributes']['class'][] = 'mdl-textfield__label';
     $variables['attributes'] = new Attribute();
-    $variables['attributes']->addClass('mdl-textfield');
-    $variables['attributes']->addClass('mdl-js-textfield');
-    $variables['attributes']->addClass('mdl-textfield--floating-label');
-  } else if ($variables['type'] == 'textarea') {
+
+    // special handling for input#keys[type=search] in SearchBlockForm
+    if ($variables['title_display'] != 'invisible') {
+      $variables['attributes']->addClass('mdl-textfield');
+      $variables['attributes']->addClass('mdl-js-textfield');
+      $variables['attributes']->addClass('mdl-textfield--floating-label');
+    }
+  }
+  if ($variables['type'] == 'textarea') {
     $variables['label_display'] = 'after';
     $variables['label']['#attributes']['class'][] = 'mdl-textfield__label';
     $variables['attributes'] = new Attribute();

--- a/templates/form-element-label.html.twig
+++ b/templates/form-element-label.html.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Theme override for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+{% if title is not empty or required -%}
+    {%- if icon -%}
+      <div{{ icon_attributes }}><i class="material-icons">{{ icon }}</i></div>
+    {%- endif -%}
+  <!--div class="mdl-selectfield__icon"><i class="material-icons">arrow_drop_down</i></div-->
+  <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+{%- endif %}

--- a/templates/textarea.html.twig
+++ b/templates/textarea.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for a 'textarea' #type form element.
+ *
+ * Available variables
+ * - wrapper_attributes: A list of HTML attributes for the wrapper element.
+ * - attributes: A list of HTML attributes for the textarea element.
+ * - resizable: An indicator for whether the textarea is resizable.
+ * - required: An indicator for whether the textarea is required.
+ * - value: The textarea content.
+ *
+ * @see template_preprocess_textarea()
+ */
+#}
+<textarea{{ attributes }}>{{ value }}</textarea>
+


### PR DESCRIPTION
- textfield,
- textarea
- mdl-selectfield atoms (comes with own js+css)

installation instructions:

##### mdl select field widget #####
bower install mdl-selectfield
mkdir -p httpdocs/libraries/mdl-selectfield
cp bower_components/mdl-selectfield/dist/mdl-selectfield.min.css httpdocs/libraries/mdl-selectfield/
cp bower_components/mdl-selectfield/dist/mdl-selectfield.min.js  httpdocs/libraries/mdl-selectfield/